### PR TITLE
Return if the URL to launch is nil

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -410,6 +410,7 @@ static void *KINContext = &KINContext;
     else if(self.uiWebView) {
         URLForActivityItem = self.uiWebView.request.URL;
     }
+    if(URLForActivityItem == nil) { return; }
     dispatch_async(dispatch_get_main_queue(), ^{
         UIActivityViewController *controller = [[UIActivityViewController alloc] initWithActivityItems:@[URLForActivityItem] applicationActivities:@[]];
         if(UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {


### PR DESCRIPTION
This fixes a crash that we have seen come across in crashlytics a bunch.

https://fabric.io/ello/ios/apps/co.ello.ello/issues/5582df16f505b5ccf02e4fbf
https://fabric.io/ello/ios/apps/co.ello.ello/issues/5584629bf505b5ccf031bc3d
https://fabric.io/ello/ios/apps/co.ello.ello/issues/5582798cf505b5ccf02d44aa
https://fabric.io/ello/ios/apps/co.ello.ello/issues/55825d95f505b5ccf02d0aef

[Fixes #97418772][Fixes #97303014][Fixes #97272842][Fixes #97267170]
