### PR TITLE
Adds a hook for determining if a page should load.

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.h
+++ b/KINWebBrowser/KINWebBrowserViewController.h
@@ -54,6 +54,7 @@
 - (void)webBrowser:(KINWebBrowserViewController *)webBrowser didStartLoadingURL:(NSURL *)URL;
 - (void)webBrowser:(KINWebBrowserViewController *)webBrowser didFinishLoadingURL:(NSURL *)URL;
 - (void)webBrowser:(KINWebBrowserViewController *)webBrowser didFailToLoadURL:(NSURL *)URL error:(NSError *)error;
+- (BOOL)webBrowser:(KINWebBrowserViewController *)webBrowser shouldStartLoadWithRequest:(NSURLRequest *)request;
 @end
 
 

--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -371,9 +371,7 @@ static void *KINContext = &KINContext;
 #pragma mark - Done Button Action
 
 - (void)doneButtonPressed:(id)sender {
-    [self.navigationController dismissViewControllerAnimated:YES completion:^{
-        [self loadURLString: @"about:blank"];
-    }];
+    [self.navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 
 

--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -98,7 +98,7 @@ static void *KINContext = &KINContext;
         else {
             self.uiWebView = [[UIWebView alloc] init];
         }
-        
+
         self.actionButtonHidden = NO;
         self.showsURLInNavigationBar = NO;
         self.showsPageTitleInNavigationBar = YES;
@@ -258,18 +258,11 @@ static void *KINContext = &KINContext;
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
     NSURLRequest *request = navigationAction.request;
-
-    BOOL *shouldLoad = YES;
+    BOOL shouldLoad = YES;
     if([self.delegate respondsToSelector:@selector(webBrowser:shouldStartLoadWithRequest:)]) {
         shouldLoad = [self.delegate webBrowser:self shouldStartLoadWithRequest:request];
     }
-
-    if (shouldLoad == YES) {
-        decisionHandler(WKNavigationActionPolicyAllow);
-    }
-    else {
-        decisionHandler(WKNavigationActionPolicyCancel);
-    }
+    decisionHandler(shouldLoad == YES ? WKNavigationActionPolicyAllow : WKNavigationActionPolicyCancel);
 }
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation {
@@ -313,7 +306,6 @@ static void *KINContext = &KINContext;
 #pragma mark - Toolbar State
 
 - (void)updateToolbarState {
-
     BOOL canGoBack = self.wkWebView.canGoBack || self.uiWebView.canGoBack;
     BOOL canGoForward = self.wkWebView.canGoForward || self.uiWebView.canGoForward;
 


### PR DESCRIPTION
Allows for intercepting the `shouldStartLoadWithRequest` for a `UIWebView` and `decidePolicyForNavigationAction` for `WKWebView`. This allows us to be able to prevent certain navigation actions and send users back into the app.
