### PR TITLE
Expose willDismiss to delegate

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.h
+++ b/KINWebBrowser/KINWebBrowserViewController.h
@@ -55,6 +55,7 @@
 - (void)webBrowser:(KINWebBrowserViewController *)webBrowser didFinishLoadingURL:(NSURL *)URL;
 - (void)webBrowser:(KINWebBrowserViewController *)webBrowser didFailToLoadURL:(NSURL *)URL error:(NSError *)error;
 - (BOOL)webBrowser:(KINWebBrowserViewController *)webBrowser shouldStartLoadWithRequest:(NSURLRequest *)request;
+- (void)willDismissWebBrowser:(KINWebBrowserViewController *)webBrowser;
 @end
 
 

--- a/KINWebBrowser/KINWebBrowserViewController.m
+++ b/KINWebBrowser/KINWebBrowserViewController.m
@@ -371,6 +371,9 @@ static void *KINContext = &KINContext;
 #pragma mark - Done Button Action
 
 - (void)doneButtonPressed:(id)sender {
+    if([self.delegate respondsToSelector:@selector(willDismissWebBrowser:)]) {
+        [self.delegate willDismissWebBrowser:self];
+    }
     [self.navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 


### PR DESCRIPTION
Landscape rotation in Ello requires the ability to change application state just prior to the KIN browser's dismissal. This PR exposes that moment through a delegate method.

`- (void)willDismissWebBrowser:(KINWebBrowserViewController *)webBrowser;`
