### PR TITLE
we need this method to be public

### DIFF
--- a/KINWebBrowser/KINWebBrowserViewController.h
+++ b/KINWebBrowser/KINWebBrowserViewController.h
@@ -122,6 +122,7 @@
 // Loads a URL as NSString to webView
 // Can be called any time after initialization
 - (void)loadURLString:(NSString *)URLString;
+- (void)doneButtonPressed:(id)sender;
 
 @end
 


### PR DESCRIPTION
In order to use the new `#selector()` syntax, this method needs to be public.
